### PR TITLE
Minor changes

### DIFF
--- a/Track.cxx
+++ b/Track.cxx
@@ -6,7 +6,7 @@ const float Track::TrackParCov::kCalcdEdxAuto = -999.f;
 
 //______________________________________________________________
 Track::TrackParBase::TrackParBase(const float xyz[3],const float pxpypz[3], int charge, bool sectorAlpha) :
-  mX(0.f),mAlpha(0.f)
+  mX{0.f},mAlpha{0.f}
 {
   // construct track param from kinematics
 
@@ -1055,7 +1055,7 @@ void Track::TrackParBase::g3helx3(float qfield, float step,float vect[7])
  *                                                                *
  ******************************************************************/
   const int ix=0, iy=1, iz=2, ipx=3, ipy=4, ipz=5, ipp=6;
-  const float kOvSqSix=sqrtf(1./6.);
+  constexpr float kOvSqSix=sqrtf(1./6.);
 
   float cosx=vect[ipx], cosy=vect[ipy], cosz=vect[ipz];
 

--- a/Track.h
+++ b/Track.h
@@ -6,7 +6,7 @@
 #define ALICEO2_BASE_TRACK
 
 #include <iostream>
-#include <stdio.h>
+#include <algorithm>
 #include <string.h>
 #include "Constants.h"
 #include "Utils.h"
@@ -14,207 +14,179 @@
 namespace AliceO2 {
   namespace Base {
     namespace Track {
-      
+
       using namespace AliceO2::Base::Constants;
       using namespace AliceO2::Base::Utils;
       using namespace std;
-      
+
       // aliases for track elements
       enum {kY,kZ,kSnp,kTgl,kQ2Pt};
       enum {kSigY2,
-	    kSigZY,kSigZ2,
-	    kSigSnpY,kSigSnpZ,kSigSnp2,
-	    kSigTglY,kSigTglZ,kSigTglSnp,kSigTgl2,
-	    kSigQ2PtY,kSigQ2PtZ,kSigQ2PtSnp,kSigQ2PtTgl,kSigQ2Pt2};
-      enum {kNParams=5,kCovMatSize=15,kLabCovMatSize=21};
-      
-      const float 
-	kCY2max=100*100, // SigmaY<=100cm
-	kCZ2max=100*100, // SigmaZ<=100cm
-	kCSnp2max=1*1,     // SigmaSin<=1
-	kCTgl2max=1*1,     // SigmaTan<=1
-	kC1Pt2max=100*100; // Sigma1/Pt<=100 1/GeV
-      
-      
+        kSigZY,kSigZ2,
+        kSigSnpY,kSigSnpZ,kSigSnp2,
+        kSigTglY,kSigTglZ,kSigTglSnp,kSigTgl2,
+        kSigQ2PtY,kSigQ2PtZ,kSigQ2PtSnp,kSigQ2PtTgl,kSigQ2Pt2};
+
+      constexpr int 
+        kNParams=5,
+        kCovMatSize=15,
+        kLabCovMatSize=21;
+
+      constexpr float 
+        kCY2max=100*100, // SigmaY<=100cm
+        kCZ2max=100*100, // SigmaZ<=100cm
+        kCSnp2max=1*1,     // SigmaSin<=1
+        kCTgl2max=1*1,     // SigmaTan<=1
+        kC1Pt2max=100*100; // Sigma1/Pt<=100 1/GeV
+
+
       class TrackParBase { // track parameterization, kinematics only. This base class cannot be instantiated
-      public:
+        public:
 
-	const float* GetParam()              const { return mP; }
-	float GetX()                         const { return mX; }
-	float GetAlpha()                     const { return mAlpha; }
-	float GetY()                         const { return mP[kY]; }
-	float GetZ()                         const { return mP[kZ]; }
-	float GetSnp()                       const { return mP[kSnp]; }
-	float GetTgl()                       const { return mP[kTgl]; }
-	float GetQ2Pt()                      const { return mP[kQ2Pt]; }
+          const float* GetParam()              const { return mP; }
+          float GetX()                         const { return mX; }
+          float GetAlpha()                     const { return mAlpha; }
+          float GetY()                         const { return mP[kY]; }
+          float GetZ()                         const { return mP[kZ]; }
+          float GetSnp()                       const { return mP[kSnp]; }
+          float GetTgl()                       const { return mP[kTgl]; }
+          float GetQ2Pt()                      const { return mP[kQ2Pt]; }
 
-	// derived getters
-	float GetCurvature(float b)          const { return mP[kQ2Pt]*b*kB2C;}
-	float GetSign()                      const { return mP[kQ2Pt]>0 ? 1.f:-1.f;}
-	float GetPhi()                       const { return asinf(GetSnp()) + GetAlpha();}
-	float GetPhiPos()                    const;
+          // derived getters
+          float GetCurvature(float b)          const { return mP[kQ2Pt]*b*kB2C;}
+          float GetSign()                      const { return mP[kQ2Pt]>0 ? 1.f:-1.f;}
+          float GetPhi()                       const { return asinf(GetSnp()) + GetAlpha();}
+          float GetPhiPos()                    const;
 
-	float GetP()                         const;
-	float GetPt()                        const;
-	void  GetXYZ(float xyz[3])           const;
-	bool  GetPxPyPz(float pxyz[3])       const;
-	bool  GetPosDir(float posdirp[9])    const;
+          float GetP()                         const;
+          float GetPt()                        const;
+          void  GetXYZ(float xyz[3])           const;
+          bool  GetPxPyPz(float pxyz[3])       const;
+          bool  GetPosDir(float posdirp[9])    const;
 
-	// parameters manipulation
-	bool  RotateParam(float alpha);
-	bool  PropagateParamTo(float xk, float b);
-	bool  PropagateParamTo(float xk, const float b[3]);
-	void  InvertParam();
+          // parameters manipulation
+          bool  RotateParam(float alpha);
+          bool  PropagateParamTo(float xk, float b);
+          bool  PropagateParamTo(float xk, const float b[3]);
+          void  InvertParam();
 
-	void  PrintParam()                   const;
+          void  PrintParam()                   const;
 
-      protected:
-	// to keep this class non-virtual but derivable the c-tors and d-tor are protected
-        TrackParBase() : mX(0),mAlpha(0) {memset(mP,0,kNParams*sizeof(float));}
-	TrackParBase(float x,float alpha, const float par[kNParams]);
-	TrackParBase(const float xyz[3],const float pxpypz[3],int sign, bool sectorAlpha=true);
-	TrackParBase(const TrackParBase& src);
-	~TrackParBase() {}
-	TrackParBase& operator=(const TrackParBase& src);
-	//
-	static void g3helx3(float qfield, float step,float vect[7]);
-	
-      protected:
-	float mX;               // X of track evaluation
-	float mAlpha;           // track frame angle
-	float mP[kNParams];     // 5 parameters: Y,Z,sin(phi),tg(lambda),q/pT
+        protected:
+          // to keep this class non-virtual but derivable the c-tors and d-tor are protected
+          TrackParBase() : mX{0.},mAlpha{0.},mP{0.f} {}
+          TrackParBase(float x,float alpha, const float par[kNParams]);
+          TrackParBase(const float xyz[3],const float pxpypz[3],int sign, bool sectorAlpha=true);
+          TrackParBase(const TrackParBase&) = default;
+          TrackParBase(TrackParBase&&) = default;
+          TrackParBase& operator=(const TrackParBase& src) = default;
+          ~TrackParBase() = default;
+          //
+          static void g3helx3(float qfield, float step,float vect[7]);
+
+          float mX;               /// X of track evaluation
+          float mAlpha;           /// track frame angle
+          float mP[kNParams];     /// 5 parameters: Y,Z,sin(phi),tg(lambda),q/pT
       };
 
       // rootcint does not swallow final keyword here
-      class TrackParCov /*final*/ : public TrackParBase { // track+error parameterization
-      public:
-	TrackParCov() { memset(mC,0,kCovMatSize*sizeof(float)); }
-	TrackParCov(float x,float alpha, const float par[kNParams], const float cov[kCovMatSize]);
-	TrackParCov(const float xyz[3],const float pxpypz[3],const float[kLabCovMatSize], int sign, bool sectorAlpha=true);
-	TrackParCov(const TrackParCov& src);
-	~TrackParCov() {}
-	TrackParCov& operator=(const TrackParCov& src);
+      class TrackParCov final : public TrackParBase { // track+error parameterization
+        public:
+          TrackParCov() : TrackParBase{}, mC{0.f} { } 
+          TrackParCov(float x,float alpha, const float par[kNParams], const float cov[kCovMatSize]);
+          TrackParCov(const float xyz[3],const float pxpypz[3],const float[kLabCovMatSize], int sign, bool sectorAlpha=true);
 
-	const float* GetCov()                const { return mC; }	
-	float GetSigmaY2()                   const { return mC[kSigY2]; }
-	float GetSigmaZY()                   const { return mC[kSigZY]; }
-	float GetSigmaZ2()                   const { return mC[kSigZ2]; }
-	float GetSigmaSnpY()                 const { return mC[kSigSnpY]; }
-	float GetSigmaSnpZ()                 const { return mC[kSigSnpZ]; }
-	float GetSigmaSnp2()                 const { return mC[kSigSnp2]; }
-	float GetSigmaTglY()                 const { return mC[kSigTglY]; }
-	float GetSigmaTglZ()                 const { return mC[kSigTglZ]; }
-	float GetSigmaTglSnp()               const { return mC[kSigTglSnp]; }
-	float GetSigmaTgl2()                 const { return mC[kSigTgl2]; }
-	float GetSigma1PtY()                 const { return mC[kSigQ2PtY]; }
-	float GetSigma1PtZ()                 const { return mC[kSigQ2PtZ]; }
-	float GetSigma1PtSnp()               const { return mC[kSigQ2PtSnp]; }
-	float GetSigma1PtTgl()               const { return mC[kSigQ2PtTgl]; }
-	float GetSigma1Pt2()                 const { return mC[kSigQ2Pt2]; }
+          const float* GetCov()                const { return mC; }	
+          float GetSigmaY2()                   const { return mC[kSigY2]; }
+          float GetSigmaZY()                   const { return mC[kSigZY]; }
+          float GetSigmaZ2()                   const { return mC[kSigZ2]; }
+          float GetSigmaSnpY()                 const { return mC[kSigSnpY]; }
+          float GetSigmaSnpZ()                 const { return mC[kSigSnpZ]; }
+          float GetSigmaSnp2()                 const { return mC[kSigSnp2]; }
+          float GetSigmaTglY()                 const { return mC[kSigTglY]; }
+          float GetSigmaTglZ()                 const { return mC[kSigTglZ]; }
+          float GetSigmaTglSnp()               const { return mC[kSigTglSnp]; }
+          float GetSigmaTgl2()                 const { return mC[kSigTgl2]; }
+          float GetSigma1PtY()                 const { return mC[kSigQ2PtY]; }
+          float GetSigma1PtZ()                 const { return mC[kSigQ2PtZ]; }
+          float GetSigma1PtSnp()               const { return mC[kSigQ2PtSnp]; }
+          float GetSigma1PtTgl()               const { return mC[kSigQ2PtTgl]; }
+          float GetSigma1Pt2()                 const { return mC[kSigQ2Pt2]; }
 
-	void  Print()                        const;
+          void  Print()                        const;
 
-	// parameters + covmat manipulation
-	bool  Rotate(float alpha);
-	bool  PropagateTo(float xk, float b);
-	bool  PropagateTo(float xk, const float b[3]);
-	void  Invert();
+          // parameters + covmat manipulation
+          bool  Rotate(float alpha);
+          bool  PropagateTo(float xk, float b);
+          bool  PropagateTo(float xk, const float b[3]);
+          void  Invert();
 
-	float GetPredictedChi2(const float p[2], const float cov[3]) const;
-	bool  Update(const float p[2], const float cov[3]);
+          float GetPredictedChi2(const float p[2], const float cov[3]) const;
+          bool  Update(const float p[2], const float cov[3]);
 
-	bool  CorrectForMaterial(float x2x0,float xrho,float mass,bool anglecorr=false,float dedx=kCalcdEdxAuto);
+          bool  CorrectForMaterial(float x2x0,float xrho,float mass,bool anglecorr=false,float dedx=kCalcdEdxAuto);
 
-	void  ResetCovariance(float s2=0);
-	void  CheckCovariance();
+          void  ResetCovariance(float s2=0);
+          void  CheckCovariance();
 
-      protected:
-	float mC[kCovMatSize];  // x, alpha + 5 parameters + 15 errors
+        protected:
+          float mC[kCovMatSize];  // x, alpha + 5 parameters + 15 errors
 
-	static const float kCalcdEdxAuto; // value indicating request for dedx calculation
+          static const float kCalcdEdxAuto; // value indicating request for dedx calculation
       };
 
-      class TrackPar /*final*/ : public TrackParBase { // track parameterization only
-      public:
-	TrackPar() {}
-        TrackPar(float x,float alpha, const float par[kNParams]) : TrackParBase(x,alpha,par) {}
-        TrackPar(const float xyz[3],const float pxpypz[3],int sign, bool sectorAlpha=true) : TrackParBase(xyz,pxpypz,sign,sectorAlpha) {}
-        TrackPar(const TrackPar& src) : TrackParBase(src) {}
-        TrackPar(const TrackParCov& src) : TrackParBase((const TrackParBase&)src) {}
-	~TrackPar() {}
-	TrackPar& operator=(const TrackPar& src) {TrackParBase::operator=((const TrackParBase&)src); return *this;}
-	//
-	void  Print() const {PrintParam();}
+      class TrackPar final : public TrackParBase { // track parameterization only
+        public:
+          TrackPar() {}
+          TrackPar(float x,float alpha, const float par[kNParams]) : TrackParBase{x,alpha,par} {}
+          TrackPar(const float xyz[3],const float pxpypz[3],int sign, bool sectorAlpha=true) : TrackParBase{xyz,pxpypz,sign,sectorAlpha} {}
+          TrackPar(const TrackParCov& src) : TrackParBase{static_cast<const TrackParBase&>(src)} {}
+          //
+          void  Print() const {PrintParam();}
       };
 
       //____________________________________________________________
-      inline TrackParBase::TrackParBase(float x, float alpha, const float par[kNParams]) : mX(x), mAlpha(alpha) {
-	// explicit constructor
-	memcpy(mP,par,kNParams*sizeof(float));
+      inline TrackParBase::TrackParBase(float x, float alpha, const float par[kNParams]) : mX{x}, mAlpha{alpha} {
+        // explicit constructor
+        std::copy(par, par + kNParams, mP);
       }
 
-      //____________________________________________________________
-      inline TrackParBase::TrackParBase(const TrackParBase& src) : mX(src.mX), mAlpha(src.mAlpha) {
-	// copy c-tor
-	memcpy(mP,src.mP,kNParams*sizeof(float));
-      }
-
-      //____________________________________________________________
-      inline TrackParBase& TrackParBase::operator=(const TrackParBase& src) {
-	// assignment operator
-	if (this!=&src) memcpy(this,&src,sizeof(TrackParBase));
-	return *this;
-      }
-      
       //_______________________________________________________
       inline void TrackParBase::GetXYZ(float xyz[3]) const {
-	// track coordinates in lab frame
-	xyz[0] = GetX(); 
-	xyz[1] = GetY();
-	xyz[2] = GetZ();
-	RotateZ(xyz,GetAlpha());
+        // track coordinates in lab frame
+        xyz[0] = GetX(); 
+        xyz[1] = GetY();
+        xyz[2] = GetZ();
+        RotateZ(xyz,GetAlpha());
       }
 
       //_______________________________________________________
       inline float TrackParBase::GetPhiPos() const {
-	// angle of track position
-	float xy[2]={GetX(),GetY()};
-	return atan2(xy[1],xy[0]);
+        // angle of track position
+        float xy[2]={GetX(),GetY()};
+        return atan2(xy[1],xy[0]);
       }
 
       //____________________________________________________________
       inline float TrackParBase::GetP() const {
-	// return the track momentum
-	float ptI = fabs(GetQ2Pt());
-	return (ptI>kAlmost0) ? sqrtf(1.f+ GetTgl()*GetTgl())/ptI : kVeryBig;
+        // return the track momentum
+        float ptI = fabs(GetQ2Pt());
+        return (ptI>kAlmost0) ? sqrtf(1.f+ GetTgl()*GetTgl())/ptI : kVeryBig;
       }
 
       //____________________________________________________________
       inline float TrackParBase::GetPt() const {
-	// return the track transverse momentum
-	float ptI = fabs(GetQ2Pt());
-	return (ptI>kAlmost0) ? 1.f/ptI : kVeryBig;
+        // return the track transverse momentum
+        float ptI = fabs(GetQ2Pt());
+        return (ptI>kAlmost0) ? 1.f/ptI : kVeryBig;
       }
 
       //============================================================
 
       //____________________________________________________________
-      inline TrackParCov::TrackParCov(float x, float alpha, const float par[kNParams], const float cov[kCovMatSize]) : TrackParBase(x,alpha,par) {
-	// explicit constructor
-	memcpy(mC,cov,kCovMatSize*sizeof(float));
-      }
-
-      //____________________________________________________________
-      inline TrackParCov::TrackParCov(const TrackParCov& src) : TrackParBase(src) {
-	// copy c-tor
-	memcpy(mC,src.GetCov(),sizeof(kCovMatSize));
-      }
-
-      //____________________________________________________________
-      inline TrackParCov& TrackParCov::operator=(const TrackParCov& src) {
-	// assignment operator
-	if (this!=&src) memcpy(mC,src.mC,kCovMatSize*sizeof(float)); 
-	return *this;
+      inline TrackParCov::TrackParCov(float x, float alpha, const float par[kNParams], const float cov[kCovMatSize]) : TrackParBase{x,alpha,par} {
+        // explicit constructor
+        std::copy(cov, cov + kCovMatSize, mC);
       }
 
     }  

--- a/test.C
+++ b/test.C
@@ -67,7 +67,7 @@ void test()
 
     if (cnt%3==0) {
       double measD[2] = {etp->GetY()+TMath::Sqrt(measErrD[0]),etp->GetZ()+TMath::Sqrt(measErrD[2])};
-      float  measF[2] = {etp->GetY()+TMath::Sqrt(measErrF[0]),etp->GetZ()+TMath::Sqrt(measErrF[2])};
+      float  measF[2] = {static_cast<float>(etp->GetY()+TMath::Sqrt(measErrF[0])),static_cast<float>(etp->GetZ()+TMath::Sqrt(measErrF[2]))};
       chi0 += trcO2->GetPredictedChi2(measF,measErrF);
       chi3 += etp->GetPredictedChi2(measD,measErrD);
       if (!trcO2->Update(measF,measErrF))  {printf("[0] Fail on update. %f\n",x); exit(1);}


### PR DESCRIPTION
Hi @shahor02, thanks for sharing the new code!
I am adding few minor changes that I did in my version of the track:
- since we use POD type data members we should leave to the compiler the definition of the constructors (in this way it will take care of defining also the move constructor)
- usage of `constexpr` keyword for values that can be computed at compile time
- usage of `std::copy` instead of `memcpy`
- avoid `memset` for setting default values of arrays

It works with ROOT6, but the code issue the warning related to the non virtual destructor (even if it is declared protected).
Could you please have a look?

Cheers,
Maximiliano